### PR TITLE
Only install and configure if afpd isn't installed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,12 @@
 ---
 # tasks file for ansible-afpd-source
+- name: Netatalk | Check if afpd is installed
+  stat:
+    path: /usr/local/sbin/afpd
+  register: afpd_check_result
+
 - include: dependencies.yml
+  when: afpd_check_result.stat.exists == False
 - include: compilation.yml
+  when: afpd_check_result.stat.exists == False
 - include: install.yml


### PR DESCRIPTION
Hi,
I've had this change sitting around for a few years ; while i still used afpd it was great not
needing to re run the first few steps all the time.

offtechnologies.afpd kgoetz$ ls -lh tasks/main.yml 
-rw-r--r--  1 kgoetz  staff   329B 13 Aug  2017 tasks/main.yml